### PR TITLE
[fix] Hide and disable irrelevant fields

### DIFF
--- a/js/directives/dtv-display-fields.js
+++ b/js/directives/dtv-display-fields.js
@@ -12,6 +12,15 @@ angular.module('risevision.displaysApp.directives')
           $scope.regionsCA = REGIONS_CA;
           $scope.regionsUS = REGIONS_US;
           $scope.timezones = TIMEZONES;
+          
+          $scope.isChromeOs = function(display) {
+            return display && display.os && display.os.indexOf('cros') !== -1;
+          };
+          
+          $scope.canReboot = function(display) {
+            // Cannot reboot Linux/Windows/Mac PackagedApp players
+            return $scope.isChromeOs(display) && display.playerName != "RisePlayerPackagedApp";
+          }
         } //link()
       };
     }

--- a/partials/display-fields.html
+++ b/partials/display-fields.html
@@ -127,7 +127,7 @@
       <i class="fa fa-refresh"></i> 
       {{ 'displays-app.fields.controls.restart.name' | translate }}
     </button>
-    <button type="button" class="btn btn-default" ng-disabled="!display.playerVersion" ng-click="confirm(displayId, 'reboot')">
+    <button type="button" class="btn btn-default" ng-disabled="!display.playerVersion || !canReboot(display)" ng-click="confirm(displayId, 'reboot')">
       <i class="fa fa-power-off"></i> 
       {{ 'displays-app.fields.controls.reboot.name' | translate }}
     </button>
@@ -141,7 +141,7 @@
       <i class="fa fa-refresh"></i> 
       {{ 'displays-app.fields.controls.restart.name' | translate }}
     </button>
-    <button type="button" class="btn btn-default btn-block half-bottom" ng-disabled="!display.playerVersion" ng-click="confirm(displayId, 'reboot')">
+    <button type="button" class="btn btn-default btn-block half-bottom" ng-disabled="!display.playerVersion || !canReboot(display)" ng-click="confirm(displayId, 'reboot')">
       <i class="fa fa-power-off"></i> 
       {{ 'displays-app.fields.controls.reboot.name' | translate }}
     </button>
@@ -158,7 +158,7 @@
   <p class="add-right text-danger" translate translate-values="{displayId: displayId}">displays-app.fields.player.playerWarning</p>
 </div>
 
-<div ng-show="displayId">
+<div ng-show="display.lastActivityDate">
   <div class="form-group form-inline">
     <label class="control-label" translate>displays-app.fields.player.resolution</label>
     <div class="form-control-static">{{display.width | resolution: display.height}}</div>
@@ -174,7 +174,7 @@
     <div class="form-control-static">{{display.os}}</div>
   </div>
   
-  <div class="form-group form-inline">
+  <div class="form-group form-inline" ng-show="isChromeOs(display)">
     <label class="control-label" translate>displays-app.fields.player.orientation.name</label>
     <select class="form-control" ng-model="display.orientation" integer-parser>
       <option value="0" translate>displays-app.fields.player.orientation.0</option>


### PR DESCRIPTION
Hide orientation field for non ChromeOs displays
Disable reboot for non ChromeOs displays that use Chrome player
Hide display fields if Display was never run