### PR TITLE
Remove empty state from address dropdowns

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.24",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v1.6.6",
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v1.8.0",
     "angular-ui-select2": "~0.0.5",
     "angular": "~1.3.0",
     "angular-mocks": "~1.3.0",

--- a/partials/display-fields.html
+++ b/partials/display-fields.html
@@ -65,8 +65,8 @@
     <div class="col-md-3">
       <div class="form-group">
         <label class="control-label" translate>displays-app.fields.address.country.name</label>
-        <select class="form-control" ng-model="display.country" ng-options="c[1] as c[0] for c in countries">
-          <option value="" translate>displays-app.fields.address.country.placeholder</option>
+        <select class="form-control" ng-model="display.country" ng-options="c.code as c.name for c in countries" empty-select-parser>
+          <option value="" ng-show="false" translate>displays-app.fields.address.country.placeholder</option>
         </select>
       </div>
     </div>
@@ -74,11 +74,11 @@
       <div class="form-group">
         <label class="control-label" translate>displays-app.fields.address.province.name</label>
         <input type="text" class="form-control" ng-model="display.province" ng-hide="display.country == 'US' || display.country == 'CA'" />
-        <select class="form-control selectpicker" ng-model="display.province" ng-options="c[1] as c[0] for c in regionsCA" ng-show="display.country == 'CA'">
-          <option value="" translate>displays-app.fields.address.province.provincePlaceholder</option>
+        <select class="form-control selectpicker" ng-model="display.province" ng-options="c[1] as c[0] for c in regionsCA" ng-show="display.country == 'CA'" empty-select-parser>
+          <option value="" ng-show="false" translate>displays-app.fields.address.province.provincePlaceholder</option>
         </select>
-        <select class="form-control selectpicker" ng-model="display.province" ng-options="c[1] as c[0] for c in regionsUS" ng-show="display.country == 'US'">
-          <option value="" translate>displays-app.fields.address.province.statePlaceholder</option>
+        <select class="form-control selectpicker" ng-model="display.province" ng-options="c[1] as c[0] for c in regionsUS" ng-show="display.country == 'US'" empty-select-parser>
+          <option value="" ng-show="false" translate>displays-app.fields.address.province.statePlaceholder</option>
         </select>
       </div>
     </div>
@@ -93,7 +93,7 @@
   <div class="form-group">
     <label class="control-label" translate>displays-app.fields.address.timezone.name</label>
     <select class="form-control" ng-model="display.timeZoneOffset" ng-options="c[1] as c[0] for c in timezones" integer-parser>
-      <option value="" translate>displays-app.fields.address.timezone.placeholder</option>
+      <option value="" ng-show="false" translate>displays-app.fields.address.timezone.placeholder</option>
     </select>
   </div>
   <hr>

--- a/partials/displays-list.html
+++ b/partials/displays-list.html
@@ -63,11 +63,11 @@
         </tr>
         <!-- If no displays available -->
         <tr ng-show="displays.list.length === 0 && !search.query">
-          <td colspan="3" class="text-center"><span translate>displays-app.list.empty</span></td>
+          <td colspan="4" class="text-center"><span translate>displays-app.list.empty</span></td>
         </tr>
         <!-- If no search results -->
         <tr ng-show="displays.list.length === 0 && search.query">
-          <td colspan="3" class="text-center"><span translate>displays-app.list.no-results</span></td>
+          <td colspan="4" class="text-center"><span translate>displays-app.list.no-results</span></td>
         </tr>
         
       </tbody>


### PR DESCRIPTION
Similar to CH fix
When the user clicks on the field, the empty state option will not show
Added directive to fields
Fixed Countries dropdown values

Fixed Displays list empty state colspan